### PR TITLE
fix: 未使用カラム final_text を削除する

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -14,7 +14,6 @@ class Roadmap(Base):
     user_input: Mapped[str] = mapped_column(Text, nullable=False)
     initial_json: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     critique: Mapped[str | None] = mapped_column(Text, nullable=True)
-    final_text: Mapped[str | None] = mapped_column(Text, nullable=True)
     final_json: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     model_name: Mapped[str | None] = mapped_column(String, nullable=True)
     input_tokens: Mapped[int | None] = mapped_column(Integer, nullable=True)

--- a/backend/routers/roadmap.py
+++ b/backend/routers/roadmap.py
@@ -27,7 +27,6 @@ def create_roadmap(req: RoadmapRequest, db: Session = Depends(get_db)):
         user_input=req.goal,
         initial_json=initial_json,
         critique=critique_text,
-        final_text=None,
         final_json=final_json,
         model_name=model_name,
         input_tokens=input_tokens,

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -25,7 +25,6 @@ class RoadmapResponse(BaseModel):
     user_input: str
     initial_json: dict | None
     critique: str | None
-    final_text: str | None
     final_json: dict | None
     model_name: str | None
     input_tokens: int | None


### PR DESCRIPTION
## Summary

- `backend/models.py` から `final_text` カラム定義を削除
- `backend/schemas.py` から `final_text` フィールド定義を削除
- `backend/routers/roadmap.py` から `final_text=None` の行を削除

## 注意

本番DB・ローカルDBで以下のSQLの手動実行が必要です。

\`\`\`sql
ALTER TABLE roadmaps DROP COLUMN final_text;
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)